### PR TITLE
Bump Deps for GHC 9.4.5

### DIFF
--- a/pg-transact-cluster.cabal
+++ b/pg-transact-cluster.cabal
@@ -26,6 +26,6 @@ library
     , monad-control ==1.0.*
     , pg-transact ==0.3.*
     , postgresql-simple ==0.6.*
-    , resource-pool >=0.2 && <0.4
+    , resource-pool >=0.4 && <0.5
     , transformers >=0.5 && <0.7
   default-language: Haskell2010


### PR DESCRIPTION
I also removed the usage of the deprecated `createPool`.