### PR TITLE
Upgrade postgresql-simple constraints

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,9 +19,9 @@ library:
 
 dependencies:
   - base >=4.15 && <4.20
-  - bytestring >=0.10 && <0.12
+  - bytestring >=0.10 && <0.13
   - monad-control ^>=1.0
   - pg-transact ^>=0.3
-  - postgresql-simple ^>=0.6
-  - resource-pool >=0.2 && <0.4
+  - postgresql-simple >=0.6 && <0.8
+  - resource-pool >=0.2 && <0.5
   - transformers >=0.5 && <0.7

--- a/pg-transact-cluster.cabal
+++ b/pg-transact-cluster.cabal
@@ -22,10 +22,10 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.15 && <4.20
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , monad-control ==1.0.*
     , pg-transact ==0.3.*
-    , postgresql-simple ==0.6.*
-    , resource-pool >=0.4 && <0.5
+    , postgresql-simple >=0.6 && <0.8
+    , resource-pool >=0.2 && <0.5
     , transformers >=0.5 && <0.7
   default-language: Haskell2010


### PR DESCRIPTION
This allows consumers to use a stackage version including GHC 9.6.4